### PR TITLE
PR: Add support for set and unordered_set, and fix typo in test.cpp

### DIFF
--- a/test.cpp
+++ b/test.cpp
@@ -2,7 +2,7 @@
 using namespace std;
 using namespace aigc;
 
-class Popole 
+class People 
 {
 public:
     string name;
@@ -10,13 +10,13 @@ public:
 
     AIGC_JSON_HELPER(name, age) //成员注册
 };
-class Student : Popole
+class Student : People
 {
 public:
     string depart;
     int grade;
     AIGC_JSON_HELPER(depart, grade) //成员注册
-    AIGC_JSON_HELPER_BASE((Popole*)this) //基类注册
+    AIGC_JSON_HELPER_BASE((People*)this) //基类注册
 };
 class Class 
 {
@@ -25,8 +25,9 @@ public:
     int test;
     std::list<Student> students;
     std::unordered_map<std::string, int> property;
-    Popole master;
-    AIGC_JSON_HELPER(name, test, students, master, property) //成员注册
+    People master;
+    std::set<std::string> users;
+    AIGC_JSON_HELPER(name, test, students, master, property, users) //成员注册
     AIGC_JSON_HELPER_DEFAULT("test=123")
 };
 
@@ -34,7 +35,8 @@ string sjson = R"({
     "name": "yaronzz", "master" : {"name" : "liu", "age" : 35}, 
     "students" : [  {"name" : "zhang", "age" : 5, "grade" : 3, "depart" : "primary school"}, 
                     {"name" : "chen", "age" : 7, "grade" : 3, "depart" : "primary school"} ],
-    "property" : {"grade" : 1, "num" : 33}
+    "property" : {"grade" : 1, "num" : 33},
+    "users": ["zhang", "chen"]
 })";
 
 int main()


### PR DESCRIPTION
Add support for set and unordered_set, fix typo in test.cpp.
For supporting set and unordered_set, additional memory copy is applied to avoid compilation error. Please refer to [inline comment](https://github.com/yizhao1998/AIGCJson/blob/19c4bb46b2dd65796519dfb8c4d5be3a4301e6dd/include/AIGCJson.hpp#L978) for more detail.